### PR TITLE
fix: openapi tags and deps versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "svc-cargo"
-version = "0.8.0-develop.4"
+version = "0.2.0"
 dependencies = [
  "axum 0.5.17",
  "cargo-husky",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "svc-cargo-client-rest"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "hyper",
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "svc-pricing-client-grpc"
 version = "0.4.1-develop.1"
-source = "git+https://github.com/Arrow-air/svc-pricing?branch=develop#06d2b1d411be6a8cee49a669168457d588d0ff09"
+source = "git+https://github.com/Arrow-air/svc-pricing?tag=v0.4.1-develop.2#06d2b1d411be6a8cee49a669168457d588d0ff09"
 dependencies = [
  "prost",
  "prost-types",
@@ -1799,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "svc-scheduler-client-grpc"
 version = "0.2.0"
-source = "git+https://github.com/Arrow-air/svc-scheduler?branch=develop#3143d5d3fbce3fd06c6b3bf7ff660f8cec02077f"
+source = "git+https://github.com/Arrow-air/svc-scheduler?tag=v0.2.5-develop.5#3143d5d3fbce3fd06c6b3bf7ff660f8cec02077f"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1810,8 +1810,8 @@ dependencies = [
 
 [[package]]
 name = "svc-storage-client-grpc"
-version = "0.9.0-develop.1"
-source = "git+https://github.com/Arrow-air/svc-storage?branch=develop#8e44758a70f479e279ddfb09255c5286b72d70fa"
+version = "0.9.0-develop.0"
+source = "git+https://github.com/Arrow-air/svc-storage?tag=v0.9.0-develop.1#62abf1aec72d5e8c923fb192e106a32d6732106e"
 dependencies = [
  "geo-types",
  "num-derive",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -34,9 +34,9 @@ prost-build               = "0.11"
 prost-types               = "0.11"
 serde                     = "1.0"
 serde_json                = "1.0"
-svc-pricing-client-grpc   = { git = "https://github.com/Arrow-air/svc-pricing", branch = "develop" }
-svc-scheduler-client-grpc = { git = "https://github.com/Arrow-air/svc-scheduler", branch = "develop" }
-svc-storage-client-grpc   = { git = "https://github.com/Arrow-air/svc-storage", branch = "develop" }
+svc-pricing-client-grpc   = { git = "https://github.com/Arrow-air/svc-pricing", tag = "v0.4.1-develop.2" }
+svc-scheduler-client-grpc = { git = "https://github.com/Arrow-air/svc-scheduler", tag = "v0.2.5-develop.5" }
+svc-storage-client-grpc   = { git = "https://github.com/Arrow-air/svc-storage", tag = "v0.9.0-develop.1" }
 tokio                     = { version = "1.20", features = ["full"] }
 tokio-util                = "0.7"
 tonic                     = "0.8"

--- a/server/src/rest_api.rs
+++ b/server/src/rest_api.rs
@@ -98,6 +98,7 @@ fn parse_flight(plan: &QueryFlightPlan) -> Option<FlightOption> {
 #[utoipa::path(
     post,
     path = "/cargo/vertiports",
+    tag = "svc-cargo",
     request_body = VertiportsQuery,
     responses(
         (status = 200, description = "List all cargo-accessible vertiports successfully", body = [Vertiport]),
@@ -164,6 +165,7 @@ pub async fn query_vertiports(
 #[utoipa::path(
     post,
     path = "/cargo/query",
+    tag = "svc-cargo",
     request_body = FlightQuery,
     responses(
         (status = 200, description = "List available flight plans", body = [FlightOption]),
@@ -331,6 +333,7 @@ pub async fn query_flight(
 #[utoipa::path(
     put,
     path = "/cargo/confirm",
+    tag = "svc-cargo",
     request_body = FlightConfirm,
     responses(
         (status = 200, description = "Flight Confirmed", body = String),
@@ -388,6 +391,7 @@ pub async fn confirm_flight(
 #[utoipa::path(
     delete,
     path = "/cargo/cancel",
+    tag = "svc-cargo",
     responses(
         (status = 200, description = "Flight cancelled successfully"),
         (status = 400, description = "Request body is invalid format"),


### PR DESCRIPTION
Adds proper tags to rest API paths so the openapi files can be combined for publishing.

Also fixes dependencies in Cargo.toml file to use tags allowing the builds to work again